### PR TITLE
Add Google Analytics 4 tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 NEXT_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,7 @@ jobs:
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          NEXT_PUBLIC_GA_MEASUREMENT_ID: ${{ secrets.NEXT_PUBLIC_GA_MEASUREMENT_ID }}
 
       - name: Add deployment files
         run: |

--- a/README.md
+++ b/README.md
@@ -46,12 +46,17 @@ template:
 ```env
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon
+NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
 ```
 
 For GitHub Pages deployments, add the same values as repository secrets named
 `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`. The deploy
 workflow validates that these values are present and that the Supabase project
 hostname resolves before building the static site.
+
+If you want Google Analytics 4 tracking, also add
+`NEXT_PUBLIC_GA_MEASUREMENT_ID`. This is the GA4 web data stream identifier and
+usually starts with `G-`.
 
 ### Supabase Tables
 

--- a/lib/gtag.ts
+++ b/lib/gtag.ts
@@ -1,0 +1,18 @@
+export const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID ?? ''
+
+declare global {
+  interface Window {
+    dataLayer: unknown[]
+    gtag?: (...args: unknown[]) => void
+  }
+}
+
+export function pageview(url: string) {
+  if (!GA_MEASUREMENT_ID || typeof window === 'undefined' || typeof window.gtag !== 'function') {
+    return
+  }
+
+  window.gtag('config', GA_MEASUREMENT_ID, {
+    page_path: url,
+  })
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,9 +1,12 @@
 import type { AppProps } from 'next/app'
 import { Inter } from 'next/font/google'
+import Script from 'next/script'
 import { useRouter } from 'next/router'
 import dynamic from 'next/dynamic'
+import { useEffect } from 'react'
 import '@/styles/globals.css'
 import 'prismjs/themes/prism-tomorrow.css'
+import { GA_MEASUREMENT_ID, pageview } from '@/lib/gtag'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -16,10 +19,51 @@ export default function App({ Component, pageProps }: AppProps) {
   const router = useRouter()
   const isArticlePage = router.pathname === '/blog/[slug]'
 
+  useEffect(() => {
+    if (!GA_MEASUREMENT_ID) {
+      return
+    }
+
+    const handleRouteChange = (url: string) => {
+      pageview(url)
+    }
+
+    router.events.on('routeChangeComplete', handleRouteChange)
+
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange)
+    }
+  }, [router.events])
+
   return (
-    <main className={inter.className}>
-      {isArticlePage && <ReadingProgress />}
-      <Component {...pageProps} />
-    </main>
+    <>
+      {GA_MEASUREMENT_ID && (
+        <>
+          <Script
+            src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+            strategy="afterInteractive"
+          />
+          <Script
+            id="google-analytics"
+            strategy="afterInteractive"
+            dangerouslySetInnerHTML={{
+              __html: `
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                window.gtag = gtag;
+                gtag('js', new Date());
+                gtag('config', '${GA_MEASUREMENT_ID}', {
+                  page_path: window.location.pathname + window.location.search,
+                });
+              `,
+            }}
+          />
+        </>
+      )}
+      <main className={inter.className}>
+        {isArticlePage && <ReadingProgress />}
+        <Component {...pageProps} />
+      </main>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- add optional Google Analytics 4 tracking for the Next.js Pages Router
- track client-side route changes for pageviews
- document the GA measurement ID env var and pass it through the deploy workflow

## Testing
- npx tsc --noEmit
- npm run build
- git diff --check