### PR TITLE
Add Google Search Console verification support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 NEXT_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
 NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
+NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=google-site-verification-token

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,7 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
           NEXT_PUBLIC_GA_MEASUREMENT_ID: ${{ secrets.NEXT_PUBLIC_GA_MEASUREMENT_ID }}
+          NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION: ${{ secrets.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION }}
 
       - name: Add deployment files
         run: |

--- a/README.md
+++ b/README.md
@@ -47,16 +47,22 @@ template:
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon
 NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
+NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=google-site-verification-token
 ```
 
 For GitHub Pages deployments, add the same values as repository secrets named
-`NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`. The deploy
-workflow validates that these values are present and that the Supabase project
-hostname resolves before building the static site.
+`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`,
+`NEXT_PUBLIC_GA_MEASUREMENT_ID`, and `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION` as
+needed. The deploy workflow validates the Supabase values before building the
+static site.
 
 If you want Google Analytics 4 tracking, also add
 `NEXT_PUBLIC_GA_MEASUREMENT_ID`. This is the GA4 web data stream identifier and
 usually starts with `G-`.
+
+If you want Google Search Console verification by meta tag, add
+`NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION`. This is the token Google gives you when
+you choose the HTML meta tag verification method.
 
 ### Supabase Tables
 

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,6 +1,8 @@
 import { Html, Head, Main, NextScript } from 'next/document'
 
 export default function Document() {
+  const googleSiteVerification = process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION ?? ''
+
   return (
     <Html lang="en">
       <Head>
@@ -12,6 +14,9 @@ export default function Document() {
           crossOrigin="anonymous"
           referrerPolicy="no-referrer"
         />
+        {googleSiteVerification && (
+          <meta name="google-site-verification" content={googleSiteVerification} />
+        )}
       </Head>
       <body>
         <Main />


### PR DESCRIPTION
## Summary
- add optional Google Search Console meta-tag verification support
- pass the verification token through the GitHub Pages deploy workflow
- document the new env var and repo secret

## Testing
- npx tsc --noEmit
- npm run build
- git diff --check