### PR TITLE
Add distributed configuration platform system design guide

### DIFF
--- a/content/blog/system-design-distributed-configuration-platform.md
+++ b/content/blog/system-design-distributed-configuration-platform.md
@@ -1,0 +1,772 @@
+---
+title: "System Design: Building a Distributed Configuration Platform"
+description: "Design a production distributed configuration platform with versioned config, rollout safety, snapshots, watchers, audit logs, multi-environment isolation, and safe client-side caching."
+date: "2026-04-10"
+category: "System Design"
+tags: ["system design", "configuration", "distributed systems", "platform engineering", "microservices", "backend engineering"]
+featured: false
+affiliateSection: "system-design-courses"
+---
+
+Most systems begin with configuration as a file.
+
+That works for a while.
+
+Then one service needs a database URL rotation without redeploy. Another wants per-environment rate limits. A third wants tenant-specific limits. A fourth wants a kill switch for an external provider. Suddenly config is no longer a startup file. It becomes a platform.
+
+When configuration is handled poorly, you get the worst sort of outages:
+
+- one bad config value breaks every service instance
+- different hosts run different config versions without anyone realizing
+- secrets leak into places they should never be
+- operators hotfix production through SSH and create permanent drift
+
+This guide designs a production distributed configuration platform.
+
+## Problem Statement
+
+Build a platform that stores and distributes configuration safely to many services.
+
+Examples of configuration:
+
+- database connection settings
+- external API endpoints
+- rate limits
+- retry policies
+- timeouts
+- per-tenant quotas
+- fraud thresholds
+- search tuning values
+- feature rollout defaults
+
+The platform should:
+
+- store versioned configuration
+- distribute updates to services
+- support environment isolation
+- provide audit history
+- make rollback easy
+- avoid requiring a database hit for every config lookup
+
+This is not a secret-management platform and not a feature-flag platform, though it may integrate with both.
+
+## Config vs Flags vs Secrets
+
+These systems are related, but they are not identical.
+
+### Configuration
+
+Relatively stable operational values used by services.
+
+Examples:
+
+- timeout = 500ms
+- payment provider base URL
+- max retries = 3
+
+### Feature flags
+
+Dynamic release and targeting logic.
+
+Examples:
+
+- enable new checkout for 10% of users
+- kill switch for recommendation engine
+
+### Secrets
+
+Sensitive values requiring stronger access control.
+
+Examples:
+
+- DB passwords
+- API keys
+- signing keys
+
+The distributed configuration platform may reference secrets, but should not casually replicate raw secret values everywhere unless that is an explicit design choice.
+
+## Requirements
+
+Functional requirements:
+
+- create and update config values
+- version all changes
+- scope config by environment, service, and optionally tenant
+- fetch a full config snapshot
+- support subscriptions or watchers for updates
+- validate config shape before publish
+- support rollback to previous version
+- audit who changed what
+- support staged rollout for dangerous config
+
+Non-functional requirements:
+
+- low-latency config reads
+- high availability
+- predictable consistency
+- strong environment isolation
+- safe behavior during config service outage
+- ability to recover from bad config pushes quickly
+
+The most important design constraint:
+
+**application instances should continue operating from a local snapshot even if the config service is temporarily unavailable.**
+
+## What Goes Wrong Without a Platform
+
+Teams often start with:
+
+- environment variables
+- static config files
+- random values in database tables
+- custom admin panels per service
+
+This causes:
+
+- no single source of truth
+- inconsistent rollout process
+- poor auditability
+- risky manual edits
+- hard-to-debug config drift
+
+Eventually, someone changes a timeout in one place, forgets three others, and the incident begins.
+
+## High-Level Architecture
+
+```text
+Admin UI / API
+      |
+      v
+Config Service
+  |
+  +-- validation
+  +-- versioning
+  +-- audit log
+  +-- publish update event
+  |
+  v
+Config Store
+  |
+  +--> snapshot API
+  +--> watch/stream API
+  |
+  v
+Client SDK / Sidecar
+  |
+  +-- local in-memory cache
+  +-- local disk snapshot
+  |
+  v
+Application
+```
+
+The runtime path should usually be:
+
+```text
+application -> local config cache
+```
+
+not:
+
+```text
+application -> remote config service -> database
+```
+
+A config service outage should not instantly break every application read path.
+
+## Data Model
+
+A good config model is versioned and scoped.
+
+```sql
+CREATE TABLE config_entries (
+  id UUID PRIMARY KEY,
+  namespace TEXT NOT NULL,          -- payments, search, checkout
+  environment TEXT NOT NULL,        -- dev, staging, prod
+  service TEXT NOT NULL,            -- payment-api, search-worker
+  config_key TEXT NOT NULL,
+  config_value JSONB NOT NULL,
+  schema_version INT NOT NULL,
+  config_version BIGINT NOT NULL,
+  status TEXT NOT NULL,             -- draft, active, archived
+  created_by TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (namespace, environment, service, config_key, config_version)
+);
+```
+
+Current active version pointer:
+
+```sql
+CREATE TABLE config_current_versions (
+  namespace TEXT NOT NULL,
+  environment TEXT NOT NULL,
+  service TEXT NOT NULL,
+  config_key TEXT NOT NULL,
+  active_version BIGINT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (namespace, environment, service, config_key)
+);
+```
+
+Audit log:
+
+```sql
+CREATE TABLE config_audit_events (
+  event_id UUID PRIMARY KEY,
+  namespace TEXT NOT NULL,
+  environment TEXT NOT NULL,
+  service TEXT NOT NULL,
+  config_key TEXT NOT NULL,
+  old_version BIGINT,
+  new_version BIGINT,
+  actor_id TEXT NOT NULL,
+  action TEXT NOT NULL,             -- created, activated, rolled_back
+  diff JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+You want history by default, not by special-case debugging effort.
+
+## Config Shape
+
+Do not treat every config value as an untyped string.
+
+Bad:
+
+```text
+PAYMENT_TIMEOUT=500
+```
+
+Good:
+
+```json
+{
+  "connectTimeoutMs": 200,
+  "readTimeoutMs": 500,
+  "maxRetries": 2,
+  "retryableStatusCodes": [429, 502, 503, 504]
+}
+```
+
+Structured config enables:
+
+- schema validation
+- safer rollouts
+- easier diffs
+- fewer parsing mistakes
+
+## Config Scoping
+
+Configuration often exists at multiple levels:
+
+- global default
+- environment override
+- service override
+- tenant override
+- emergency override
+
+Example resolution order:
+
+```text
+global default
+  -> environment
+  -> service
+  -> tenant
+  -> emergency override
+```
+
+That means a request for config may involve layered merging.
+
+Example:
+
+```json
+{
+  "baseTimeoutMs": 500,
+  "maxRetries": 3
+}
+```
+
+Production override:
+
+```json
+{
+  "maxRetries": 2
+}
+```
+
+Resolved result:
+
+```json
+{
+  "baseTimeoutMs": 500,
+  "maxRetries": 2
+}
+```
+
+Keep inheritance explicit. Hidden override chains are a debugging nightmare.
+
+## Validation
+
+Never let arbitrary config become active just because it is valid JSON.
+
+Validate:
+
+- schema shape
+- type correctness
+- required fields
+- numeric ranges
+- enum values
+- semantic rules
+
+Example JSON schema idea:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "connectTimeoutMs": { "type": "integer", "minimum": 50, "maximum": 5000 },
+    "readTimeoutMs": { "type": "integer", "minimum": 50, "maximum": 10000 },
+    "maxRetries": { "type": "integer", "minimum": 0, "maximum": 10 }
+  },
+  "required": ["connectTimeoutMs", "readTimeoutMs", "maxRetries"]
+}
+```
+
+And semantic validation:
+
+```text
+connectTimeoutMs <= readTimeoutMs
+```
+
+One mis-typed value should not be able to break the fleet.
+
+## Publish Workflow
+
+Configuration changes should not be "write directly to prod and hope."
+
+Safer workflow:
+
+1. create draft
+2. validate
+3. review / approve if sensitive
+4. activate
+5. publish update event
+6. monitor rollout
+7. rollback if necessary
+
+For high-risk config:
+
+- require two-person approval
+- limit changes to business hours
+- enforce canary rollout
+
+## Snapshot Fetch vs Streaming Updates
+
+Clients need two capabilities:
+
+### 1. full snapshot fetch
+
+On startup:
+
+```text
+GET /v1/config/snapshot?service=payment-api&environment=prod
+```
+
+This returns the full resolved config.
+
+### 2. watch / stream updates
+
+While running:
+
+```text
+stream config_update events
+```
+
+This can be implemented with:
+
+- long polling
+- SSE
+- WebSocket
+- Kafka-backed sidecar
+
+Most systems use full snapshot on boot and incremental updates afterward.
+
+## Client SDK
+
+The client library or sidecar matters more than people first assume.
+
+Responsibilities:
+
+- fetch initial snapshot
+- cache resolved config in memory
+- keep last known good snapshot on disk
+- subscribe to updates
+- expose typed getters
+- avoid breaking app startup when control plane is down
+
+Example interface:
+
+```java
+public interface ConfigClient {
+    <T> T get(String key, Class<T> type);
+    <T> T getOrDefault(String key, Class<T> type, T defaultValue);
+    ConfigSnapshot snapshot();
+}
+```
+
+Simple usage:
+
+```java
+PaymentTimeoutConfig cfg = configClient.get("payment.http", PaymentTimeoutConfig.class);
+httpClient.setReadTimeout(cfg.readTimeoutMs());
+```
+
+The application should not parse raw JSON strings everywhere.
+
+## Local Snapshot Safety
+
+One of the most important production behaviors is fallback to last known good config.
+
+Example startup policy:
+
+1. try fetch fresh snapshot from config service
+2. if unavailable, load last successful local snapshot
+3. if neither available, use safe startup defaults or fail explicitly
+
+That prevents config control-plane outages from becoming full application outages.
+
+Store local snapshot:
+
+```json
+{
+  "environment": "prod",
+  "service": "payment-api",
+  "version": 417,
+  "fetchedAt": "2026-04-10T10:05:00Z",
+  "values": {
+    "payment.http": {
+      "connectTimeoutMs": 200,
+      "readTimeoutMs": 500,
+      "maxRetries": 2
+    }
+  }
+}
+```
+
+## Consistency Model
+
+Configuration systems are usually eventually consistent across the fleet.
+
+That can be acceptable if:
+
+- updates propagate quickly
+- version is visible
+- services can tolerate short windows of mixed config
+
+But some config is more dangerous than others.
+
+Examples:
+
+- log level change: eventual consistency fine
+- fraud threshold change: probably okay with short lag
+- DB credential rotation: much more sensitive
+
+So configs should be classified by rollout safety level.
+
+## Safe Rollouts
+
+Not every config should go from 0% to 100% instantly.
+
+Options:
+
+### 1. all-at-once activation
+
+Good for:
+
+- low-risk observability tweaks
+- noncritical UI defaults
+
+### 2. canary rollout
+
+Activate for:
+
+- 1 instance
+- then 5%
+- then 25%
+- then full fleet
+
+Good for:
+
+- HTTP client tuning
+- search ranking parameters
+- queue worker batch sizes
+
+### 3. staged by environment
+
+Dev -> staging -> prod
+
+Mandatory for most risky configuration.
+
+## Multi-Environment Isolation
+
+This should be strict.
+
+Production config must not be editable from the same casual path as development config.
+
+Best practices:
+
+- separate environment namespaces
+- separate IAM / RBAC
+- explicit UI coloring and confirmation
+- separate audit streams if needed
+
+Teams have caused real incidents by editing staging or prod in the wrong browser tab. Your platform should not make that easy.
+
+## Secrets Integration
+
+The config platform should not be a casual secret dump.
+
+Better pattern:
+
+```json
+{
+  "dbSecretRef": "vault://prod/payments/db-primary"
+}
+```
+
+Then the runtime or a secret client resolves it.
+
+This keeps:
+
+- audit boundaries clearer
+- rotation easier
+- sensitive material out of broad config snapshots
+
+## Change Propagation
+
+How do clients know something changed?
+
+Common pattern:
+
+1. config service writes new active version
+2. transaction writes config change event to outbox
+3. relay publishes to update stream
+4. clients receive event and refresh
+
+Example event:
+
+```json
+{
+  "namespace": "payments",
+  "environment": "prod",
+  "service": "payment-api",
+  "configKey": "payment.http",
+  "version": 418,
+  "updatedAt": "2026-04-10T10:08:00Z"
+}
+```
+
+Clients should still verify version ordering before applying updates.
+
+## Rollback
+
+Rollback should be a first-class operation, not manual JSON editing.
+
+Example rollback flow:
+
+1. operator selects previous version 417
+2. platform activates version 417 again
+3. update event published
+4. clients revert
+
+If rollback means "copy-paste old config from Slack," your platform is not done.
+
+## Failure Modes
+
+### 1. Bad config activates fleet-wide
+
+Fix:
+
+- validation
+- approval workflow
+- canary rollout
+- instant rollback
+
+### 2. Partial fleet update
+
+Some instances get version 418, others stay on 417.
+
+Fix:
+
+- expose current config version per instance
+- alert on prolonged skew
+
+### 3. Config service outage
+
+Fix:
+
+- local last-known-good snapshots
+- in-memory cache
+- no request-path dependency on remote reads
+
+### 4. Secret leaked through config export
+
+Fix:
+
+- separate secret references from plain config
+- redact sensitive fields in logs and UI
+
+### 5. Invalid override chain
+
+Tenant override accidentally nulls a required field.
+
+Fix:
+
+- validate final merged config, not only each layer independently
+
+## Observability
+
+Track:
+
+- snapshot fetch latency
+- update propagation latency
+- config version skew across instances
+- validation failures
+- rollback frequency
+- failed client refresh count
+- most frequently changed keys
+
+Useful dashboards:
+
+- latest config version per service
+- oldest instance still on outdated version
+- recent high-risk config changes
+- config-related incident annotations
+
+## Example API
+
+Create draft:
+
+```http
+POST /v1/config/drafts
+```
+
+```json
+{
+  "namespace": "payments",
+  "environment": "prod",
+  "service": "payment-api",
+  "configKey": "payment.http",
+  "value": {
+    "connectTimeoutMs": 200,
+    "readTimeoutMs": 500,
+    "maxRetries": 2
+  }
+}
+```
+
+Activate version:
+
+```http
+POST /v1/config/activate
+```
+
+```json
+{
+  "namespace": "payments",
+  "environment": "prod",
+  "service": "payment-api",
+  "configKey": "payment.http",
+  "version": 418
+}
+```
+
+Snapshot:
+
+```http
+GET /v1/config/snapshot?environment=prod&service=payment-api
+```
+
+## Example Client Refresh Logic
+
+```java
+public class ConfigRefreshService {
+
+    public void onConfigUpdate(ConfigUpdateEvent event) {
+        long currentVersion = localStore.currentVersion(event.configKey());
+        if (event.version() <= currentVersion) {
+            return;
+        }
+
+        ConfigValue latest = remoteClient.fetchResolvedConfig(
+            event.environment(),
+            event.service(),
+            event.configKey()
+        );
+
+        validator.validate(latest);
+        localStore.apply(event.configKey(), latest, event.version());
+    }
+}
+```
+
+Again, the important thing is boring correctness:
+
+- ignore stale updates
+- validate before applying
+- persist local snapshot
+
+## What I Would Build First
+
+Phase 1:
+
+- versioned config store
+- snapshot API
+- client library with local cache
+- audit log
+
+Phase 2:
+
+- update streaming
+- rollback tooling
+- layered overrides
+- schema validation
+
+Phase 3:
+
+- staged rollout / canary
+- tenant-scoped overrides
+- approval workflows for risky config
+- instance skew dashboards
+
+This order matters. Teams often jump into fancy dynamic reload behavior before they have history, rollback, and validation.
+
+## Production Checklist
+
+- config versioned by default
+- active version pointer explicit
+- full snapshot available
+- clients keep last-known-good state
+- schema validation enforced
+- merged config validated after overrides
+- audit log retained
+- rollback one click away
+- dangerous config supports canary rollout
+- services expose current config version
+
+## Final Takeaway
+
+A distributed configuration platform is a control plane for operational behavior.
+
+If you design it well, teams can change safe things quickly, risky things carefully, and recover from mistakes fast.
+
+If you design it poorly, config becomes an invisible source of outages that nobody trusts and everybody works around.
+
+## Read Next
+
+- [System Design: Building a Feature Flag Platform](/blog/system-design-feature-flag-platform/)
+- [System Design: Building an Authorization Service](/blog/system-design-authorization-service/)
+- [System Design: Building a Distributed Cache](/blog/system-design-distributed-cache/)


### PR DESCRIPTION
## Summary
- add a long-form system design guide for a distributed configuration platform
- cover versioned config, validation, snapshots, update propagation, local caches, rollback, and rollout safety
- add practical schema and code examples plus a production checklist

## Testing
- npx tsc --noEmit
- npm run build
- git diff --check